### PR TITLE
Fix typo in README license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you’re unsure, create a Discussion first.
 
 ## License
 
-MIT © Julius Brusssee
+MIT © Julius Brussee
 
 If you use this library in academic work, please cite it:
 


### PR DESCRIPTION
## Summary
- correct Julius Brusssee typo in README license section

## Testing
- `grep -n "Brussee" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_686157e4d048832d96def10147aa72e2