### PR TITLE
Fix quick start cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```bash
 # Clone and explore
 $ git clone https://github.com/juliusbrussee/the-prompt-library.git
-$ cd prompt-library
+$ cd the-prompt-library
 
 # List available prompts
 $ ./scripts/list_prompts.sh


### PR DESCRIPTION
## Summary
- update the Quick start example to use the actual repo name

## Testing
- `python -m py_compile scripts/csv_to_yaml.py scripts/generate_index.py`
- `bash scripts/setup_folders.sh`

------
https://chatgpt.com/codex/tasks/task_e_686157e3c3a8832d89a6ced93c7efef2