### PR TITLE
Fix index generation for acronym categories

### DIFF
--- a/prompts/design-ux/INDEX.md
+++ b/prompts/design-ux/INDEX.md
@@ -1,4 +1,4 @@
-# Design Ux Prompts
+# Design UX Prompts
 
 * [**Accessibility Auditor.** — Provide recommendations to improve contrast and navigability of **{page_url}**…](accessibility-auditor.prompt.yaml)
 * [**Brand Color Consultant.** — Recommend color palette for **{industry}** brand aiming to evoke **{emotion}**,…](brand-color-consultant.prompt.yaml)

--- a/prompts/marketing-seo/INDEX.md
+++ b/prompts/marketing-seo/INDEX.md
@@ -1,4 +1,4 @@
-# Marketing Seo Prompts
+# Marketing SEO Prompts
 
 * [**A/B Test Strategist.** — Outline A/B test for landing page **{page_url}**; define hypothesis, variants,…](a-b-test-strategist.prompt.yaml)
 * [**Buyer Persona Developer.** — Build detailed persona for **{audience_segment}** interested in **{product}**…](buyer-persona-developer.prompt.yaml)

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -20,6 +20,13 @@ PROMPTS_DIR = REPO_ROOT / "prompts"
 INDEX_FILENAME = "INDEX.md"
 
 
+def pretty_category_name(slug: str) -> str:
+    """Return human-friendly category title preserving known acronyms."""
+    specials = {"seo": "SEO", "ux": "UX", "ai": "AI"}
+    parts = slug.split("-")
+    return " ".join(specials.get(p, p.capitalize()) for p in parts)
+
+
 def summary_line(prompt_data: dict) -> str:
     """Return a concise one‑liner e.g. 'Veteran Tech Opinion Columnist – Craft a 1,200‑word editorial…'"""
     role = prompt_data.get("role", "<missing role>")
@@ -34,7 +41,7 @@ def build_index_for_category(cat_path: Path):
     if not prompt_files:
         return
 
-    lines = [f"# {cat_path.name.replace('-', ' ').title()} Prompts", ""]
+    lines = [f"# {pretty_category_name(cat_path.name)} Prompts", ""]
 
     for f in prompt_files:
         data = yaml.safe_load(f.read_text())


### PR DESCRIPTION
## Summary
- keep acronyms like `SEO` and `UX` capitalized when generating category INDEXes
- regenerate index pages with the corrected titles

## Testing
- `python scripts/generate_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6861572489d4832d8b434e1a8470f951