### PR TITLE
Fix permissions for publish workflow

### DIFF
--- a/.github/workflows/publish-prompts.yml
+++ b/.github/workflows/publish-prompts.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- ensure the `publish-prompts` workflow has permissions to push updates and deploy the docs

## Testing
- `pytest -q`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686535f83100832daab90a30f10bc23f